### PR TITLE
vendoring ThirdPartyIdentifier changes of v2

### DIFF
--- a/vendor/github.com/RealImage/moviebuff-sdk-go/v2/movie.go
+++ b/vendor/github.com/RealImage/moviebuff-sdk-go/v2/movie.go
@@ -225,16 +225,19 @@ type Movie struct {
 		AE string `json:"AE"`
 	} `json:"releaseStatuses"`
 
-	ThirdPartyIdentifiers []struct {
-		IDs    []string `json:"ids"`
-		Source struct {
-			UUID string `json:"uuid"`
-			Name string `json:"name"`
-		} `json:"source"`
-	} `json:"thirdPartyIdentifiers"`
+	ThirdPartyIdentifiers []ThirdPartyIdentifier `json:"thirdPartyIdentifiers"`
 
 	MoviebuffURL string `json:"moviebuffUrl"`
 	APIPath      string `json:"apiPath"`
+}
+
+//ThirdPartyIdentifier has third-party sources
+type ThirdPartyIdentifier struct {
+	IDs    []string `json:"ids"`
+	Source struct {
+		UUID string `json:"uuid"`
+		Name string `json:"name"`
+	} `json:"source"`
 }
 
 // GetEarliestReleaseYear return the year at which movie was first released anywhere in the world.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/RealImage/moviebuff-sdk-go/v2 v2.0.0
+# github.com/RealImage/moviebuff-sdk-go/v2 v2.0.1-0.20200508083834-63725fa16a33
 github.com/RealImage/moviebuff-sdk-go/v2
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew


### PR DESCRIPTION
- vendor root module based on the [pull request](https://github.com/RealImage/moviebuff-sdk-go/pull/10)